### PR TITLE
bee-pollinator: deploy Supervisor Agent programmatically

### DIFF
--- a/demos/bee-pollinator/README.md
+++ b/demos/bee-pollinator/README.md
@@ -52,7 +52,7 @@ databricks bundle run setup_demo \
 
 Add `--profile your_profile` if not using the default CLI profile.
 
-This creates 3 Delta tables, uploads 4 PDFs to a UC Volume, and creates a Genie Space and Knowledge Assistant — all automated.
+This creates 3 Delta tables, uploads 4 PDFs to a UC Volume, and creates the Genie Space, Knowledge Assistant, and Supervisor Agent — all automated.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -60,47 +60,11 @@ This creates 3 Delta tables, uploads 4 PDFs to a UC Volume, and creates a Genie 
 | `schema` | `bee_pollinator` | Schema for demo tables |
 | `warehouse_id` | — (required) | SQL Warehouse ID for Genie Space |
 
-### Step 3: Create the Supervisor Agent (~5 minutes)
-
-The Supervisor Agent has no API yet, so this step is done in the UI.
-
-1. Navigate to **Agents** in the left sidebar
-2. Click **Create Supervisor Agent** (or **+ New** > **Supervisor Agent**)
-3. Fill in the fields:
-   - **Name:** `Bee Colony Health Advisor`
-   - **Description:** `Routes questions about bee colony health between USDA statistical data and beekeeping guidance documents`
-   - **Add Agents:**
-     - Click **Add Agent** and select **`USDA Bee Health Data`** (Genie Space)
-     - Click **Add Agent** again and select **`Bee Health Documents`** (Knowledge Assistant via Agent Endpoint)
-   - Click **Optional->Instructions:**
-   Add the instructions for the Supervisor Agent.
-
-```
-You are a bee colony health and pollinator conservation advisor. You help beekeepers, farmers, and agricultural extension agents by combining USDA data analysis with expert guidance from beekeeping and conservation documents.
-
-Route questions as follows:
-
-1. Data/Statistics → Genie Space (USDA Bee Health Data)
-   Questions about annual honey production, colony counts, honey pricing, and trends over time.
-   Questions about quarterly colony loss and quarterly stressors by state, year, and quarter.
-   If asked for annual colony loss or annual stressor conclusions, answer quarter-by-quarter instead.
-
-2. Guidance/Best Practices → Knowledge Assistant (Bee Health Documents)
-   Questions about varroa management, treatment protocols, USDA programs, habitat creation, native plants.
-
-3. Combined → Both Agents
-   Questions that need both data context and expert guidance. Use data to establish context, then documents for actionable recommendations.
-
-When synthesizing from both agents, connect the data insight to the document guidance and provide specific, actionable recommendations. Cite data sources and document sections.
-```
-
-4. Click **Create Agent**
-
-### Step 4: Verify
+### Step 3: Verify
 
 Confirm in the Databricks UI:
 - **Data** > your catalog > your schema: 3 tables (`honey_production`, `colony_loss`, `colony_stressors`) and a `guidance_docs` volume with 4 PDFs
-- **Agents**: Genie Space, Knowledge Assistant, and Supervisor Agent all present
+- **Agents**: Genie Space (`USDA Bee Health Data`), Knowledge Assistant (`Bee Health Documents`), and Supervisor Agent (`Bee Colony Health Advisor`) all present
 - Knowledge Assistant indexing may take 1-3 minutes to finish
 
 Test the Supervisor Agent with these queries:
@@ -120,7 +84,7 @@ python scripts/setup_data.py --catalog your_catalog --schema bee_health
 python scripts/setup_agents.py --catalog your_catalog --schema bee_health --warehouse-id your_warehouse_id
 ```
 
-Then create the Supervisor Agent manually per Step 2 above.
+This creates the Genie Space, Knowledge Assistant, and Supervisor Agent — no manual UI step.
 
 ## Running the Demo
 
@@ -166,8 +130,9 @@ databricks bundle destroy
 
 # Tables, schema, volume, and agents must be cleaned up separately:
 #   - Drop schema (cascades to tables and volume)
-#   - Delete Genie Space and Knowledge Assistant from the UI or via SDK
-#   - Delete Supervisor Agent from the UI
+#   - Delete Genie Space, Knowledge Assistant, and Supervisor Agent
+#     from the UI or via SDK (w.supervisor_agents.delete_supervisor_agent,
+#     w.knowledge_assistants.delete_knowledge_assistant, w.genie.trash_space)
 ```
 
 ## Troubleshooting
@@ -176,7 +141,7 @@ databricks bundle destroy
 |---------|----------|
 | `bundle validate` auth error | Run `databricks auth login --profile your_profile` |
 | `load_data` task fails reading CSVs | Verify bundle deployed: `databricks workspace ls "/Workspace/Users/<you>/.bundle/bee-pollinator-demo/dev/files/data/snapshots"` |
-| `create_agents` fails with missing module | Bump `databricks-sdk` version in `databricks.yml` |
+| `create_agents` fails with missing module or `supervisor_agents` attribute | Bump `databricks-sdk` to `>=0.106.0` in `databricks.yml` (bundle path) or `pyproject.toml` / `requirements.txt` (local CLI path) |
 | "Table not found" in Genie | Verify tables exist in Data browser; re-run `bundle run setup_demo` |
 | KA returns "No relevant documents" | Check PDFs in the `guidance_docs` volume; wait for indexing to finish |
 | Supervisor routes incorrectly | Verify both sub-agents are added; check instructions are pasted correctly; test sub-agents individually first |

--- a/demos/bee-pollinator/README.md
+++ b/demos/bee-pollinator/README.md
@@ -60,14 +60,17 @@ This creates 3 Delta tables, uploads 4 PDFs to a UC Volume, and creates the Geni
 | `schema` | `bee_pollinator` | Schema for demo tables |
 | `warehouse_id` | — (required) | SQL Warehouse ID for Genie Space |
 
-### Step 3: Verify
+### Step 3: Wait for indexing
+
+The Knowledge Assistant indexes the PDFs after creation. For this demo's ~140 pages this typically takes **~10 minutes** (sometimes longer). The Supervisor Agent will return apologetic, ungrounded responses to document questions until indexing completes — that's the signal to wait.
+
+### Step 4: Verify
 
 Confirm in the Databricks UI:
 - **Data** > your catalog > your schema: 3 tables (`honey_production`, `colony_loss`, `colony_stressors`) and a `guidance_docs` volume with 4 PDFs
 - **Agents**: Genie Space (`USDA Bee Health Data`), Knowledge Assistant (`Bee Health Documents`), and Supervisor Agent (`Bee Colony Health Advisor`) all present
-- Knowledge Assistant indexing may take 1-3 minutes to finish
 
-Test the Supervisor Agent with these queries:
+Test the Supervisor Agent in the **Agents** UI with these queries:
 
 | Type | Query |
 |------|-------|
@@ -77,14 +80,24 @@ Test the Supervisor Agent with these queries:
 
 Honey questions can stay annual. Colony-loss and stressor questions should stay quarterly because the USDA Honey Bee Colonies data in this demo is quarter-based. Use `max_colonies` with `loss_colonies` when you need quarter-specific scale.
 
+Or run the same three queries from the CLI:
+
+```bash
+pip install -r requirements.txt    # or: uv pip install -r requirements.txt
+python scripts/verify_demo.py --supervisor "Bee Colony Health Advisor" --profile your_profile
+```
+
+The script resolves the display name to the supervisor's serving endpoint (`mas-XXXXXXXX-endpoint`) and reports pass/fail per query.
+
 ### Alternative: Local CLI setup (no DABs)
 
 ```bash
-python scripts/setup_data.py --catalog your_catalog --schema bee_health
-python scripts/setup_agents.py --catalog your_catalog --schema bee_health --warehouse-id your_warehouse_id
+pip install -r requirements.txt    # or: uv pip install -r requirements.txt
+python scripts/setup_data.py --catalog your_catalog --schema your_schema
+python scripts/setup_agents.py --catalog your_catalog --schema your_schema --warehouse-id your_warehouse_id
 ```
 
-This creates the Genie Space, Knowledge Assistant, and Supervisor Agent — no manual UI step.
+This creates the Genie Space, Knowledge Assistant, and Supervisor Agent — no manual UI step. Use the same `--schema` for both commands.
 
 ## Running the Demo
 

--- a/demos/bee-pollinator/databricks.yml
+++ b/demos/bee-pollinator/databricks.yml
@@ -1,8 +1,8 @@
 # Databricks Asset Bundle configuration for the Bee Pollinator demo.
 #
 # Deploys a single job that loads data, uploads PDFs, and creates
-# the Genie Space + Knowledge Assistant. The Supervisor Agent must
-# still be created manually (no SDK support yet).
+# the Genie Space, Knowledge Assistant, and Supervisor Agent end-to-end.
+# Fully programmatic — no UI steps required.
 #
 # Usage:
 #   databricks bundle validate
@@ -51,7 +51,9 @@ resources:
           spec:
             client: "1"
             dependencies:
-              - databricks-sdk>=0.44.0
+              # >=0.106.0 exposes w.supervisor_agents (programmatic
+              # Supervisor Agent creation, no UI step required).
+              - databricks-sdk>=0.106.0
 
 targets:
   dev:

--- a/demos/bee-pollinator/pyproject.toml
+++ b/demos/bee-pollinator/pyproject.toml
@@ -6,14 +6,14 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "databricks-sdk>=0.106.0",
+    "databricks-openai>=0.5.0",
     "requests>=2.31.0",
     "pandas>=2.0.0",
     "mlflow>=2.10.0",
 ]
 
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+# Demo scripts only — not packaged or installed. Use `uv pip install -r
+# requirements.txt` (or `uv sync --no-install-project`) to install deps.
 
 [tool.ruff]
 line-length = 100

--- a/demos/bee-pollinator/pyproject.toml
+++ b/demos/bee-pollinator/pyproject.toml
@@ -5,7 +5,7 @@ description = "Databricks AI demo for bee and pollinator health analysis using U
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "databricks-sdk>=0.20.0",
+    "databricks-sdk>=0.106.0",
     "requests>=2.31.0",
     "pandas>=2.0.0",
     "mlflow>=2.10.0",

--- a/demos/bee-pollinator/requirements.txt
+++ b/demos/bee-pollinator/requirements.txt
@@ -4,6 +4,9 @@
 # >=0.106.0 exposes w.supervisor_agents (programmatic Supervisor Agent creation).
 databricks-sdk>=0.106.0
 
+# Used by scripts/verify_demo.py to query the Supervisor Agent endpoint.
+databricks-openai>=0.5.0
+
 # Data fetching and processing
 requests>=2.31.0
 pandas>=2.0.0

--- a/demos/bee-pollinator/requirements.txt
+++ b/demos/bee-pollinator/requirements.txt
@@ -1,7 +1,8 @@
 # Bee Pollinator Demo Dependencies
 
-# Databricks SDK for agent creation and workspace management
-databricks-sdk>=0.20.0
+# Databricks SDK for agent creation and workspace management.
+# >=0.106.0 exposes w.supervisor_agents (programmatic Supervisor Agent creation).
+databricks-sdk>=0.106.0
 
 # Data fetching and processing
 requests>=2.31.0

--- a/demos/bee-pollinator/scripts/create_agents.py
+++ b/demos/bee-pollinator/scripts/create_agents.py
@@ -83,7 +83,9 @@ ka_name, ka_id = setup_agents.create_knowledge_assistant(
 
 # --- Create Supervisor Agent ---
 
-supervisor_name = setup_agents.create_supervisor_agent(w, genie_id, ka_id)
+supervisor_resource, supervisor_endpoint = setup_agents.create_supervisor_agent(
+    w, genie_id, ka_id
+)
 
 # COMMAND ----------
 
@@ -92,5 +94,7 @@ print("AGENT SETUP COMPLETE")
 print(f"{'=' * 60}")
 print(f"\nGenie Space: {genie_id}")
 print(f"Knowledge Assistant: {ka_name}")
-print(f"Supervisor Agent: {supervisor_name}")
-print("\nKnowledge Assistant indexing may take 1-3 minutes to complete.")
+print(f"Supervisor Agent: {supervisor_resource}")
+if supervisor_endpoint:
+    print(f"Supervisor endpoint: {supervisor_endpoint}")
+print("\nKnowledge Assistant indexing typically takes ~10 minutes for ~140 pages.")

--- a/demos/bee-pollinator/scripts/create_agents.py
+++ b/demos/bee-pollinator/scripts/create_agents.py
@@ -1,6 +1,7 @@
 # Databricks notebook source
 """
-Create Genie Space and Knowledge Assistant for the bee-pollinator demo.
+Create Genie Space, Knowledge Assistant, and Supervisor Agent for the
+bee-pollinator demo. Fully programmatic — no UI steps required.
 
 Runs as a Databricks job task within the DAB bundle. Uses the Databricks SDK
 (pre-installed on serverless) with automatic workspace authentication.
@@ -74,15 +75,15 @@ genie_id = setup_agents.create_genie_space(
 
 # --- Create Knowledge Assistant ---
 
-ka_id = setup_agents.create_knowledge_assistant(
+ka_name, ka_id = setup_agents.create_knowledge_assistant(
     w, catalog, schema, "guidance_docs", "Bee Health Documents"
 )
 
 # COMMAND ----------
 
-# --- Print Supervisor Agent instructions (manual step) ---
+# --- Create Supervisor Agent ---
 
-setup_agents.print_supervisor_instructions("USDA Bee Health Data", "Bee Health Documents")
+supervisor_name = setup_agents.create_supervisor_agent(w, genie_id, ka_id)
 
 # COMMAND ----------
 
@@ -90,5 +91,6 @@ print(f"\n{'=' * 60}")
 print("AGENT SETUP COMPLETE")
 print(f"{'=' * 60}")
 print(f"\nGenie Space: {genie_id}")
-print(f"Knowledge Assistant: {ka_id}")
-print("\nNext: Create Supervisor Agent manually (see instructions above)")
+print(f"Knowledge Assistant: {ka_name}")
+print(f"Supervisor Agent: {supervisor_name}")
+print("\nKnowledge Assistant indexing may take 1-3 minutes to complete.")

--- a/demos/bee-pollinator/scripts/setup_agents.py
+++ b/demos/bee-pollinator/scripts/setup_agents.py
@@ -1,14 +1,14 @@
 """
 Bee Pollinator Demo - Agent Setup Script
 
-Creates a Genie Space and Knowledge Assistant using the Databricks SDK.
-The Supervisor Agent must still be created manually via the UI.
+Creates the Genie Space, Knowledge Assistant, and Supervisor Agent
+fully programmatically via the Databricks SDK — no manual UI step.
 
 Prerequisites:
 - Databricks workspace with Unity Catalog enabled
 - Delta tables created (run setup_data.py first)
 - PDFs uploaded to UC Volume
-- Python packages: databricks-sdk
+- databricks-sdk >= 0.106.0 (exposes w.supervisor_agents)
 
 Usage:
     python setup_agents.py --catalog your_catalog --schema bee_health --warehouse-id your_warehouse_id
@@ -28,6 +28,12 @@ try:
         FilesSpec,
         KnowledgeAssistant,
         KnowledgeSource,
+    )
+    from databricks.sdk.service.supervisoragents import (
+        GenieSpace as SupervisorGenieSpace,
+        KnowledgeAssistant as SupervisorKnowledgeAssistant,
+        SupervisorAgent,
+        Tool,
     )
 except ImportError as _import_err:
     # When run as CLI, exit immediately. When imported as a module (e.g. from
@@ -162,6 +168,31 @@ KA_DESCRIPTION = (
 )
 
 KA_SOURCE_NAME = "Bee Health Guidance PDFs"
+
+SUPERVISOR_NAME = "Bee Colony Health Advisor"
+
+SUPERVISOR_DESCRIPTION = (
+    "Routes questions about bee colony health between USDA statistical "
+    "data (Genie) and beekeeping guidance documents (Knowledge Assistant)."
+)
+
+GENIE_TOOL_ID = "usda_bee_health_data"
+
+KA_TOOL_ID = "bee_health_documents"
+
+GENIE_TOOL_DESCRIPTION = (
+    "USDA Bee Health Data — annual honey production metrics and quarterly "
+    "colony loss / stressor data by state (2015-2025). Use for questions "
+    "about production trends, colony counts, pricing, quarterly loss "
+    "percentages, and stressor breakdowns."
+)
+
+KA_TOOL_DESCRIPTION = (
+    "Bee Health Documents — guidance from varroa management, USDA "
+    "pollinator priorities, agricultural habitat, and native plant "
+    "documents. Use for questions about treatment protocols, conservation "
+    "programs, IPM strategies, and habitat recommendations."
+)
 
 
 def _genie_id() -> str:
@@ -356,8 +387,12 @@ def _knowledge_assistant_name(assistant: KnowledgeAssistant) -> str:
 
 def create_knowledge_assistant(
     w: WorkspaceClient, catalog: str, schema: str, volume: str, ka_name: str
-) -> str:
-    """Create or reuse a Knowledge Assistant and attach the bee health volume."""
+) -> tuple[str, str]:
+    """Create or reuse a Knowledge Assistant and attach the bee health volume.
+
+    Returns (resource_name, knowledge_assistant_id) where resource_name is of
+    the form 'knowledge-assistants/{id}' and knowledge_assistant_id is the UUID.
+    """
     print(f"\nCreating Knowledge Assistant: {ka_name}")
     _require_sdk_capability(
         w,
@@ -402,28 +437,105 @@ def create_knowledge_assistant(
     w.knowledge_assistants.sync_knowledge_sources(name=assistant_name)
     print("  ✓ Knowledge Assistant sync triggered")
 
-    return assistant_name
+    return assistant_name, assistant.id
 
 
-def print_supervisor_instructions(genie_name: str, ka_name: str):
-    """Print Supervisor Agent creation instructions."""
-    print("\n" + "="*60)
-    print("SUPERVISOR AGENT CREATION (Manual - No API Available)")
-    print("="*60)
+def _get_existing_supervisor_agent(
+    w: WorkspaceClient, display_name: str
+) -> SupervisorAgent | None:
+    """Look up an existing Supervisor Agent by display name."""
+    for agent in w.supervisor_agents.list_supervisor_agents():
+        if agent.display_name == display_name:
+            return agent
+    return None
 
-    print("\n📋 Manual Supervisor Agent Creation Steps:")
-    print("  1. Navigate to 'AI Playground' → 'Agents' in your workspace")
-    print("  2. Create new 'Supervisor Agent'")
-    print("  3. Name: Bee Colony Health Advisor")
-    print("  4. Add tools/agents:")
-    print(f"     - Add the Genie Space you created ({genie_name})")
-    print(f"     - Add the Knowledge Assistant you created ({ka_name})")
-    print("  5. Supervisor Instructions: Copy from SUPERVISOR_INSTRUCTIONS below")
-    print("\n" + "="*60)
-    print("SUPERVISOR INSTRUCTIONS:")
-    print("="*60)
-    print(SUPERVISOR_INSTRUCTIONS)
-    print("="*60)
+
+def _supervisor_agent_name(agent: SupervisorAgent) -> str:
+    """Return the resource name for a Supervisor Agent."""
+    if agent.name:
+        return agent.name
+    if agent.supervisor_agent_id:
+        return f"supervisor-agents/{agent.supervisor_agent_id}"
+    if agent.id:
+        return f"supervisor-agents/{agent.id}"
+    raise RuntimeError("Supervisor Agent response did not include a resource name.")
+
+
+def _existing_tool_ids(w: WorkspaceClient, parent: str) -> set[str]:
+    """Return the set of tool_ids already attached to a Supervisor Agent."""
+    tool_ids: set[str] = set()
+    for tool in w.supervisor_agents.list_tools(parent=parent):
+        tid = tool.tool_id or (tool.name.rsplit("/", 1)[-1] if tool.name else None)
+        if tid:
+            tool_ids.add(tid)
+    return tool_ids
+
+
+def create_supervisor_agent(
+    w: WorkspaceClient,
+    genie_space_id: str,
+    ka_id: str,
+    supervisor_name: str = SUPERVISOR_NAME,
+) -> str:
+    """Create or reuse a Supervisor Agent wired to the Genie Space and KA.
+
+    Returns the supervisor agent resource name (supervisor-agents/{id}).
+    """
+    print(f"\nCreating Supervisor Agent: {supervisor_name}")
+    _require_sdk_capability(
+        w,
+        "supervisor_agents",
+        "This databricks-sdk version does not expose Supervisor Agent APIs. "
+        "Run: pip install --upgrade 'databricks-sdk>=0.106.0'",
+    )
+
+    agent = _get_existing_supervisor_agent(w, supervisor_name)
+    if agent is None:
+        agent = w.supervisor_agents.create_supervisor_agent(
+            supervisor_agent=SupervisorAgent(
+                display_name=supervisor_name,
+                description=SUPERVISOR_DESCRIPTION,
+                instructions=SUPERVISOR_INSTRUCTIONS,
+            )
+        )
+        print(f"  ✓ Supervisor Agent created: {agent.supervisor_agent_id or agent.id}")
+    else:
+        print(f"  ✓ Supervisor Agent already exists: {agent.supervisor_agent_id or agent.id}")
+
+    parent = _supervisor_agent_name(agent)
+    existing_tool_ids = _existing_tool_ids(w, parent)
+
+    if GENIE_TOOL_ID not in existing_tool_ids:
+        w.supervisor_agents.create_tool(
+            parent=parent,
+            tool=Tool(
+                tool_type="genie_space",
+                description=GENIE_TOOL_DESCRIPTION,
+                genie_space=SupervisorGenieSpace(id=genie_space_id),
+            ),
+            tool_id=GENIE_TOOL_ID,
+        )
+        print(f"  ✓ Attached Genie Space tool: {GENIE_TOOL_ID}")
+    else:
+        print(f"  ✓ Genie Space tool already attached: {GENIE_TOOL_ID}")
+
+    if KA_TOOL_ID not in existing_tool_ids:
+        w.supervisor_agents.create_tool(
+            parent=parent,
+            tool=Tool(
+                tool_type="knowledge_assistant",
+                description=KA_TOOL_DESCRIPTION,
+                knowledge_assistant=SupervisorKnowledgeAssistant(
+                    knowledge_assistant_id=ka_id
+                ),
+            ),
+            tool_id=KA_TOOL_ID,
+        )
+        print(f"  ✓ Attached Knowledge Assistant tool: {KA_TOOL_ID}")
+    else:
+        print(f"  ✓ Knowledge Assistant tool already attached: {KA_TOOL_ID}")
+
+    return parent
 
 
 def main():
@@ -447,6 +559,11 @@ def main():
         default="guidance_docs",
         help="UC Volume name for documents (default: guidance_docs)",
     )
+    parser.add_argument(
+        "--supervisor-name",
+        default=SUPERVISOR_NAME,
+        help=f"Supervisor Agent name (default: {SUPERVISOR_NAME})",
+    )
 
     args = parser.parse_args()
 
@@ -464,12 +581,14 @@ def main():
     )
 
     # Create Knowledge Assistant
-    ka_id = create_knowledge_assistant(
+    ka_name, ka_id = create_knowledge_assistant(
         w, args.catalog, args.schema, args.volume, args.ka_name
     )
 
-    # Print Supervisor instructions
-    print_supervisor_instructions(args.genie_name, args.ka_name)
+    # Create Supervisor Agent (programmatic — no UI step required)
+    supervisor_name = create_supervisor_agent(
+        w, genie_id, ka_id, supervisor_name=args.supervisor_name
+    )
 
     # Summary
     print("\n" + "="*60)
@@ -477,12 +596,11 @@ def main():
     print("="*60)
 
     print(f"\n✓ Genie Space ready: {genie_id}")
-    print(f"✓ Knowledge Assistant ready: {ka_id}")
-    print("✓ Supervisor instructions printed")
+    print(f"✓ Knowledge Assistant ready: {ka_name}")
+    print(f"✓ Supervisor Agent ready: {supervisor_name}")
     print("\nNext steps:")
-    print("1. Create Supervisor Agent manually (see instructions above)")
-    print("2. Wait for Knowledge Assistant indexing to complete")
-    print("3. Test the demo with verification queries")
+    print("1. Wait for Knowledge Assistant indexing to complete (1-3 min)")
+    print("2. Test the demo with verification queries")
 
 
 if __name__ == "__main__":

--- a/demos/bee-pollinator/scripts/setup_agents.py
+++ b/demos/bee-pollinator/scripts/setup_agents.py
@@ -323,6 +323,15 @@ def _build_genie_serialized_space(catalog: str, schema: str) -> str:
     return json.dumps(serialized_space)
 
 
+def _get_existing_genie_space(w: WorkspaceClient, title: str) -> str | None:
+    """Look up an existing Genie Space by exact title; returns its space_id or None."""
+    resp = w.genie.list_spaces()
+    for s in (resp.spaces or []):
+        if s.title == title:
+            return s.space_id
+    return None
+
+
 def create_genie_space(
     w: WorkspaceClient,
     catalog: str,
@@ -330,7 +339,7 @@ def create_genie_space(
     warehouse_id: str,
     space_name: str,
 ) -> str:
-    """Create a Genie Space with the bee health demo tables and instructions."""
+    """Create or reuse a Genie Space with the bee health demo tables and instructions."""
     print(f"\nCreating Genie Space: {space_name}")
     _require_sdk_capability(
         w,
@@ -344,6 +353,11 @@ def create_genie_space(
         "This databricks-sdk version does not expose w.genie.create_space. "
         "Run: pip install --upgrade databricks-sdk",
     )
+
+    existing_id = _get_existing_genie_space(w, space_name)
+    if existing_id is not None:
+        print(f"  ✓ Genie Space already exists: {existing_id}")
+        return existing_id
 
     space = w.genie.create_space(
         warehouse_id=warehouse_id,
@@ -476,10 +490,12 @@ def create_supervisor_agent(
     genie_space_id: str,
     ka_id: str,
     supervisor_name: str = SUPERVISOR_NAME,
-) -> str:
+) -> tuple[str, str | None]:
     """Create or reuse a Supervisor Agent wired to the Genie Space and KA.
 
-    Returns the supervisor agent resource name (supervisor-agents/{id}).
+    Returns (resource_name, endpoint_name) where resource_name is of the form
+    'supervisor-agents/{id}' and endpoint_name is the serving endpoint
+    ('mas-XXXXXXXX-endpoint') used to invoke the agent.
     """
     print(f"\nCreating Supervisor Agent: {supervisor_name}")
     _require_sdk_capability(
@@ -503,6 +519,11 @@ def create_supervisor_agent(
         print(f"  ✓ Supervisor Agent already exists: {agent.supervisor_agent_id or agent.id}")
 
     parent = _supervisor_agent_name(agent)
+
+    # list_supervisor_agents may omit endpoint_name; refetch if needed.
+    if not agent.endpoint_name:
+        agent = w.supervisor_agents.get_supervisor_agent(name=parent)
+
     existing_tool_ids = _existing_tool_ids(w, parent)
 
     if GENIE_TOOL_ID not in existing_tool_ids:
@@ -535,7 +556,10 @@ def create_supervisor_agent(
     else:
         print(f"  ✓ Knowledge Assistant tool already attached: {KA_TOOL_ID}")
 
-    return parent
+    if agent.endpoint_name:
+        print(f"  ✓ Endpoint: {agent.endpoint_name}")
+
+    return parent, agent.endpoint_name
 
 
 def main():
@@ -586,7 +610,7 @@ def main():
     )
 
     # Create Supervisor Agent (programmatic — no UI step required)
-    supervisor_name = create_supervisor_agent(
+    supervisor_resource, supervisor_endpoint = create_supervisor_agent(
         w, genie_id, ka_id, supervisor_name=args.supervisor_name
     )
 
@@ -597,10 +621,12 @@ def main():
 
     print(f"\n✓ Genie Space ready: {genie_id}")
     print(f"✓ Knowledge Assistant ready: {ka_name}")
-    print(f"✓ Supervisor Agent ready: {supervisor_name}")
+    print(f"✓ Supervisor Agent ready: {supervisor_resource}")
+    if supervisor_endpoint:
+        print(f"✓ Supervisor endpoint: {supervisor_endpoint}")
     print("\nNext steps:")
-    print("1. Wait for Knowledge Assistant indexing to complete (1-3 min)")
-    print("2. Test the demo with verification queries")
+    print("1. Wait for Knowledge Assistant indexing to complete (~10 min for ~140 pages)")
+    print(f"2. Verify with: python scripts/verify_demo.py --supervisor '{args.supervisor_name}'")
 
 
 if __name__ == "__main__":

--- a/demos/bee-pollinator/scripts/verify_demo.py
+++ b/demos/bee-pollinator/scripts/verify_demo.py
@@ -3,6 +3,11 @@ Bee Pollinator Demo - Verification Script
 
 Tests the deployed Supervisor Agent with sample queries to verify everything works.
 
+The --supervisor argument accepts either the display name (e.g.
+"Bee Colony Health Advisor") or the serving endpoint name (e.g.
+"mas-XXXXXXXX-endpoint"). Display names are resolved to the endpoint
+via the Databricks SDK.
+
 Usage:
     python verify_demo.py --supervisor "Bee Colony Health Advisor"
     python verify_demo.py --supervisor "Bee Colony Health Advisor" --profile your_profile
@@ -45,6 +50,28 @@ TEST_QUERIES = [
 ]
 
 
+def resolve_supervisor_endpoint(w: WorkspaceClient, supervisor: str) -> str:
+    """Resolve a display name to its serving endpoint, or pass through if already an endpoint."""
+    if supervisor.startswith("mas-") and supervisor.endswith("-endpoint"):
+        return supervisor
+    for agent in w.supervisor_agents.list_supervisor_agents():
+        if agent.display_name == supervisor:
+            endpoint = agent.endpoint_name
+            if not endpoint and agent.name:
+                endpoint = w.supervisor_agents.get_supervisor_agent(name=agent.name).endpoint_name
+            if not endpoint:
+                raise RuntimeError(
+                    f"Supervisor Agent '{supervisor}' has no endpoint_name. "
+                    "It may still be provisioning — try again in a minute."
+                )
+            return endpoint
+    raise RuntimeError(
+        f"No Supervisor Agent found with display name '{supervisor}'. "
+        f"Pass an endpoint name (mas-XXXXXXXX-endpoint) instead, or check that "
+        f"setup_demo finished successfully."
+    )
+
+
 def query_agent(client: DatabricksOpenAI, supervisor_name: str, query: str) -> str:
     """Query the supervisor agent and return response text."""
     try:
@@ -77,7 +104,11 @@ def check_success(response: str, indicators: list) -> bool:
 
 def main():
     parser = argparse.ArgumentParser(description="Verify bee pollinator demo")
-    parser.add_argument("--supervisor", required=True, help="Supervisor agent name or endpoint")
+    parser.add_argument(
+        "--supervisor",
+        required=True,
+        help="Supervisor Agent display name or serving endpoint name",
+    )
     parser.add_argument("--profile", default=None, help="Databricks CLI profile name")
     parser.add_argument("--verbose", action="store_true", help="Show full responses")
 
@@ -92,7 +123,11 @@ def main():
     w = WorkspaceClient(profile=args.profile) if args.profile else WorkspaceClient()
     client = DatabricksOpenAI()
 
-    # Get experiment for MLflow tracing
+    endpoint = resolve_supervisor_endpoint(w, args.supervisor)
+    if endpoint != args.supervisor:
+        print(f"  Resolved '{args.supervisor}' → endpoint '{endpoint}'")
+
+    # Get experiment for MLflow tracing (named after the supervisor display name).
     try:
         experiment = mlflow.get_experiment_by_name(args.supervisor)
         if experiment:
@@ -100,7 +135,7 @@ def main():
     except Exception as e:
         print(f"⚠ Could not find MLflow experiment: {e}")
 
-    print(f"\nTesting Supervisor Agent: {args.supervisor}")
+    print(f"\nTesting Supervisor Agent endpoint: {endpoint}")
     print(f"Running {len(TEST_QUERIES)} test queries...\n")
 
     # Run test queries
@@ -111,7 +146,7 @@ def main():
 
         # Query the agent
         start_time = time.time()
-        response = query_agent(client, args.supervisor, test["query"])
+        response = query_agent(client, endpoint, test["query"])
         elapsed = time.time() - start_time
 
         # Check success
@@ -151,10 +186,6 @@ def main():
 
     if passed == total:
         print("\n🎉 All tests passed! Demo is ready.")
-        print("\nNext steps:")
-        print("1. Review DEMO_GUIDE.md for booth demo flow")
-        print("2. Bookmark the Supervisor Agent URL")
-        print("3. Test on conference WiFi if possible")
         sys.exit(0)
     else:
         print("\n⚠ Some tests failed. Review errors above.")


### PR DESCRIPTION
## Summary

- Drops the manual UI step from the bee-pollinator demo. The Supervisor Agent and its Genie + KA child tools are now created via `w.supervisor_agents` (`databricks-sdk >= 0.106.0`), so `databricks bundle run setup_demo` deploys the entire stack end-to-end.
- Adds `create_supervisor_agent()` to `scripts/setup_agents.py` (idempotent — reuses an existing agent and skips already-attached tools), wires it into the bundle notebook `scripts/create_agents.py`, and updates the README/teardown notes accordingly.
- Bumps the SDK floor to `0.106.0` in `databricks.yml`, `pyproject.toml`, and `requirements.txt`.

## Test plan
- [x] Tore down prior sandbox demo (supervisor + KA + Genie space + bundle job + schema), then `bundle deploy` + `bundle run setup_demo` against `dl_demo` on the sandbox profile.
- [x] Confirmed the supervisor `Bee Colony Health Advisor` was created with both `usda_bee_health_data` (genie_space) and `bee_health_documents` (knowledge_assistant) tools attached automatically.
- [x] Ran `scripts/verify_demo.py` against the supervisor endpoint — all three queries (Genie, KA, cross-modal) returned grounded answers after KA indexing finished.
- [ ] Reviewer to spot-check the SDK wiring against the upstream [SupervisorAgentsAPI docs](https://databricks-sdk-py.readthedocs.io/en/latest/workspace/supervisoragents/supervisor_agents.html).

This pull request and its description were written by Isaac.